### PR TITLE
added cost tags in additional_aws_tags in calling module

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -6,6 +6,8 @@ locals {
     Owner      = "Organization_Name"
     Expires    = "Never"
     Department = "Engineering"
+    Product    = "Atmosly"
+    Environment = local.environment
   }
   kms_key_arn  = "arn:aws:kms:us-west-1:xxxxxxx:key/mrk-xxxxxxx" # pass ARN of EKS created KMS key
   ipv6_enabled = false


### PR DESCRIPTION
**1. Add the following cost tags to the additional_aws_tags in the calling module:**

**Product = "Atmosly"
Environment = local.environment**

Currently, I have added these cost-related tags to the additional_aws_tags in the local block of the calling module. These tags are being applied to IAM roles, S3 buckets, and the EFS service in AWS. Additionally, the tags are being passed to the vpc-cni addon, and ebs-csi driver which you can verify from the EKS cluster's console.

However, the tags are not yet being applied to volumes (EBS). I haven't worked on that aspect yet.

**Validation Checklist for the below mentioned service:**

**Validate the tags for:**

1. IAM roles
2. EFS service
3. vpc-cni addon tags from the EKS cluster's default addon console
4. ebs-csi driver tags from the EKS cluster's default addons console


Do not need to test the remaining services for tag application at this time.






