### PR TITLE
Provide support of additionl tags with added cost tags in all the aws resources.

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -6,7 +6,7 @@ locals {
     Owner      = "Organization_Name"
     Expires    = "Never"
     Department = "Engineering"
-    Product    = "Atmosly"
+    Product    = ""
     Environment = local.environment
   }
   kms_key_arn  = "arn:aws:kms:us-west-1:xxxxxxx:key/mrk-xxxxxxx" # pass ARN of EKS created KMS key
@@ -39,6 +39,8 @@ module "eks-addons" {
   ## EBS-STORAGE-CLASS
   single_az_ebs_gp3_storage_class_enabled = false # to enable ebs gp3 storage class
   single_az_sc_config                     = [{ name = "infra-service-sc", zone = "${local.region}a" }]
+  tag_product                             = local.additional_tags.Product
+  tag_environment                         = local.environment
 
   ## EfS-STORAGE-CLASS
   efs_storage_class_enabled = false # to enable EBS storage class
@@ -77,9 +79,9 @@ module "eks-addons" {
   }
 
   ## KARPENTER-PROVISIONER
-  karpenter_provisioner_enabled = false # to enable provisioning nodes with Karpenter in the EKS cluster
+ karpenter_provisioner_enabled = false # to enable provisioning nodes with Karpenter in the EKS cluster
   karpenter_provisioner_config = {
-    provisioner_name              = format("karpenter-provisioner")
+    provisioner_name              = format("karpenter-provisioner-%s", local.name)
     karpenter_label               = ["Mgt-Services", "Monitor-Services", "ECK-Services"]
     provisioner_values            = file("./config/karpenter-management.yaml")
     instance_capacity_type        = ["spot"]
@@ -87,14 +89,12 @@ module "eks-addons" {
     ec2_instance_family           = ["t3"]
     ec2_instance_type             = ["t3.medium"]
     private_subnet_selector_key   = "Environment"
-    private_subnet_selector_key   = "Karpenter"
-    private_subnet_selector_value = "${local.name}-${local.region}a"
+    private_subnet_selector_value = local.environment
+    security_group_selector_key   = "aws:eks:cluster-name"
     security_group_selector_value = "${local.environment}-${local.name}"
     instance_hypervisor           = ["nitro"]
     kms_key_arn                   = local.kms_key_arn
-    ec2_node_name                 = "${local.environment}-${local.name}"
   }
-
   ## coreDNS-HPA (cluster-proportional-autoscaler)
   coredns_hpa_enabled = false # to enable core-dns HPA
   coredns_hpa_helm_config = {
@@ -112,7 +112,7 @@ module "eks-addons" {
   cert_manager_helm_config = {
     values                         = [file("${path.module}/config/cert-manager.yaml")]
     enable_service_monitor         = false # to enable monitoring for Cert Manager
-    cert_manager_letsencrypt_email = "email@email.com"
+    cert_manager_letsencrypt_email = "mona@squareops.com"
   }
 
   ## CONFIG-RELOADER

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -112,7 +112,7 @@ module "eks-addons" {
   cert_manager_helm_config = {
     values                         = [file("${path.module}/config/cert-manager.yaml")]
     enable_service_monitor         = false # to enable monitoring for Cert Manager
-    cert_manager_letsencrypt_email = "mona@squareops.com"
+    cert_manager_letsencrypt_email = "email@email.com"
   }
 
   ## CONFIG-RELOADER

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -39,8 +39,6 @@ module "eks-addons" {
   ## EBS-STORAGE-CLASS
   single_az_ebs_gp3_storage_class_enabled = false # to enable ebs gp3 storage class
   single_az_sc_config                     = [{ name = "infra-service-sc", zone = "${local.region}a" }]
-  tag_product                             = local.additional_tags.Product
-  tag_environment                         = local.environment
 
   ## EfS-STORAGE-CLASS
   efs_storage_class_enabled = false # to enable EBS storage class

--- a/main.tf
+++ b/main.tf
@@ -156,8 +156,6 @@ module "ingress-nginx" {
   private_nlb_enabled    = var.private_nlb_enabled
   ingress_class_name     = var.private_nlb_enabled ? "internal-${var.ingress_nginx_config.ingress_class_name}" : var.ingress_nginx_config.ingress_class_name
   enable_service_monitor = var.ingress_nginx_config.enable_service_monitor
-  tag_product                = var.tag_product
-  tag_environment            = var.tag_environment
 }
 
 # INGRESS-NGINX DATA SOURCE
@@ -191,8 +189,6 @@ module "karpenter-provisioner" {
   depends_on       = [module.karpenter]
   ipv6_enabled     = var.ipv6_enabled
   karpenter_config = var.karpenter_provisioner_config
-  tag_product                = var.tag_product
-  tag_environment            = var.tag_environment
 }
 
 ## KUBERNETES DASHBOARD
@@ -252,8 +248,7 @@ module "single-az-sc" {
   availability_zone                    = each.value.zone
   single_az_ebs_gp3_storage_class      = var.single_az_ebs_gp3_storage_class_enabled
   single_az_ebs_gp3_storage_class_name = each.value.name
-  tag_product                = var.tag_product
-  tag_environment            = var.tag_environment
+  tags_all                             = var.tags
 }
 
 ## SERVICE MONITOR CRD

--- a/main.tf
+++ b/main.tf
@@ -156,6 +156,8 @@ module "ingress-nginx" {
   private_nlb_enabled    = var.private_nlb_enabled
   ingress_class_name     = var.private_nlb_enabled ? "internal-${var.ingress_nginx_config.ingress_class_name}" : var.ingress_nginx_config.ingress_class_name
   enable_service_monitor = var.ingress_nginx_config.enable_service_monitor
+  tag_product                = var.tag_product
+  tag_environment            = var.tag_environment
 }
 
 # INGRESS-NGINX DATA SOURCE
@@ -189,6 +191,8 @@ module "karpenter-provisioner" {
   depends_on       = [module.karpenter]
   ipv6_enabled     = var.ipv6_enabled
   karpenter_config = var.karpenter_provisioner_config
+  tag_product                = var.tag_product
+  tag_environment            = var.tag_environment
 }
 
 ## KUBERNETES DASHBOARD
@@ -248,6 +252,8 @@ module "single-az-sc" {
   availability_zone                    = each.value.zone
   single_az_ebs_gp3_storage_class      = var.single_az_ebs_gp3_storage_class_enabled
   single_az_ebs_gp3_storage_class_name = each.value.name
+  tag_product                = var.tag_product
+  tag_environment            = var.tag_environment
 }
 
 ## SERVICE MONITOR CRD

--- a/modules/aws-ebs-storage-class/main.tf
+++ b/modules/aws-ebs-storage-class/main.tf
@@ -12,5 +12,7 @@ resource "kubernetes_storage_class_v1" "single_az_sc" {
     encrypted = true
     kmskeyId  = var.kms_key_id
     zone      = var.availability_zone
+    tagSpecification_1 ="Product=${var.tag_product}"
+    tagSpecification_2 = "Environment=${var.tag_environment}"
   }
 }

--- a/modules/aws-ebs-storage-class/main.tf
+++ b/modules/aws-ebs-storage-class/main.tf
@@ -7,12 +7,13 @@ resource "kubernetes_storage_class_v1" "single_az_sc" {
   reclaim_policy         = "Retain"
   allow_volume_expansion = true
   volume_binding_mode    = "WaitForFirstConsumer"
-  parameters = {
-    type      = "gp3"
-    encrypted = true
-    kmskeyId  = var.kms_key_id
-    zone      = var.availability_zone
-    tagSpecification_1 ="Product=${var.tag_product}"
-    tagSpecification_2 = "Environment=${var.tag_environment}"
-  }
+  parameters = merge(
+    {
+      type      = "gp3"
+      encrypted = true
+      kmskeyId  = var.kms_key_id
+      zone      = var.availability_zone
+    },
+    { for k, v in var.tags_all : "tagSpecification_${k}" => "${k}=${v}" }
+  )
 }

--- a/modules/aws-ebs-storage-class/variables.tf
+++ b/modules/aws-ebs-storage-class/variables.tf
@@ -20,3 +20,13 @@ variable "availability_zone" {
   type        = any
   description = "List of Azs"
 }
+
+variable "tag_product" {
+  description = "Tag for Product"
+  type        = string
+}
+
+variable "tag_environment" {
+  description = "Tag for Environment"
+  type        = string
+}

--- a/modules/aws-ebs-storage-class/variables.tf
+++ b/modules/aws-ebs-storage-class/variables.tf
@@ -21,12 +21,8 @@ variable "availability_zone" {
   description = "List of Azs"
 }
 
-variable "tag_product" {
-  description = "Tag for Product"
-  type        = string
-}
-
-variable "tag_environment" {
-  description = "Tag for Environment"
-  type        = string
+variable "tags_all" {
+  description = "Additional tags (e.g. `map('BusinessUnit`,`XYZ`)"
+  type        = map(string)
+  default     = {}
 }

--- a/modules/ingress-nginx/config/ingress_nginx.yaml
+++ b/modules/ingress-nginx/config/ingress_nginx.yaml
@@ -7,7 +7,7 @@ controller:
       service.beta.kubernetes.io/aws-load-balancer-type: nlb
       service.beta.kubernetes.io/aws-load-balancer-internal: "${private_nlb_enabled}"
       service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
-      service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: "Product=${tag_product},Environment=${tag_environment}"
+      service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: "${additional_tags}"
     externalTrafficPolicy: Cluster
 
 

--- a/modules/ingress-nginx/config/ingress_nginx.yaml
+++ b/modules/ingress-nginx/config/ingress_nginx.yaml
@@ -7,6 +7,7 @@ controller:
       service.beta.kubernetes.io/aws-load-balancer-type: nlb
       service.beta.kubernetes.io/aws-load-balancer-internal: "${private_nlb_enabled}"
       service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
+      service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: "Product=${tag_product},Environment=${tag_environment}"
     externalTrafficPolicy: Cluster
 
 

--- a/modules/ingress-nginx/config/ingress_nginx_ipv6.yaml
+++ b/modules/ingress-nginx/config/ingress_nginx_ipv6.yaml
@@ -9,7 +9,7 @@ controller:
       service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
       service.beta.kubernetes.io/aws-load-balancer-ip-address-type: dualstack
       service.beta.kubernetes.io/aws-load-balancer-scheme: ${nlb_scheme}
-      service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: "Product=${tag_product},Environment=${tag_environment}"
+      service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: "${additional_tags}"
     externalTrafficPolicy: Cluster
     ipFamilies:
     - IPv6
@@ -22,7 +22,7 @@ controller:
         service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
         service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
         service.beta.kubernetes.io/aws-load-balancer-ip-address-type: dualstack
-        service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: "Product=${tag_product},Environment=${tag_environment}"
+        service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: "${additional_tags}"
       ingressClass: ${ingress_class_name}
 
   ingressClassResource:

--- a/modules/ingress-nginx/config/ingress_nginx_ipv6.yaml
+++ b/modules/ingress-nginx/config/ingress_nginx_ipv6.yaml
@@ -9,6 +9,7 @@ controller:
       service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
       service.beta.kubernetes.io/aws-load-balancer-ip-address-type: dualstack
       service.beta.kubernetes.io/aws-load-balancer-scheme: ${nlb_scheme}
+      service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: "Product=${tag_product},Environment=${tag_environment}"
     externalTrafficPolicy: Cluster
     ipFamilies:
     - IPv6
@@ -21,6 +22,7 @@ controller:
         service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
         service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
         service.beta.kubernetes.io/aws-load-balancer-ip-address-type: dualstack
+        service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: "Product=${tag_product},Environment=${tag_environment}"
       ingressClass: ${ingress_class_name}
 
   ingressClassResource:

--- a/modules/ingress-nginx/main.tf
+++ b/modules/ingress-nginx/main.tf
@@ -2,6 +2,7 @@ locals {
   namespace     = var.namespace
   nlb_scheme    = var.private_nlb_enabled ? "internal" : "internet-facing"
   template_path = "${path.module}/config/${var.ip_family == "ipv4" ? "ingress_nginx.yaml" : "ingress_nginx_ipv6.yaml"}"
+  additional_tags = join(",", [for k, v in var.addon_context.tags : "${k}=${v}"])
 
   # Read module's template file
   template_values = templatefile(local.template_path, {
@@ -9,8 +10,7 @@ locals {
     private_nlb_enabled    = var.private_nlb_enabled
     nlb_scheme             = local.nlb_scheme
     ingress_class_name     = var.ingress_class_name
-    tag_product                = var.tag_product
-    tag_environment            = var.tag_environment
+    additional_tags    = local.additional_tags  # Pass the dynamically created string
   })
 
   # Convert the template values to a map

--- a/modules/ingress-nginx/main.tf
+++ b/modules/ingress-nginx/main.tf
@@ -9,6 +9,8 @@ locals {
     private_nlb_enabled    = var.private_nlb_enabled
     nlb_scheme             = local.nlb_scheme
     ingress_class_name     = var.ingress_class_name
+    tag_product                = var.tag_product
+    tag_environment            = var.tag_environment
   })
 
   # Convert the template values to a map

--- a/modules/ingress-nginx/variables.tf
+++ b/modules/ingress-nginx/variables.tf
@@ -54,3 +54,13 @@ variable "namespace" {
   description = "Creates namespace for the controller need to install"
   type        = string
 }
+
+variable "tag_product" {
+  description = "Tag for Product"
+  type        = string
+}
+
+variable "tag_environment" {
+  description = "Tag for Environment"
+  type        = string
+}

--- a/modules/ingress-nginx/variables.tf
+++ b/modules/ingress-nginx/variables.tf
@@ -55,12 +55,3 @@ variable "namespace" {
   type        = string
 }
 
-variable "tag_product" {
-  description = "Tag for Product"
-  type        = string
-}
-
-variable "tag_environment" {
-  description = "Tag for Environment"
-  type        = string
-}

--- a/modules/karpenter-provisioner/config/ipv4-values.yaml
+++ b/modules/karpenter-provisioner/config/ipv4-values.yaml
@@ -10,6 +10,8 @@ provisioner_name: "${provisioner_name}"
 instance_capacity_type: "${instance_capacity_type}"
 kms_key_id: "${kms_key_id}"
 ec2_node_name: "${ec2_node_name}"
+tag_product: "${tag_product}"
+tag_environment: "${tag_environment}"
 
 
 spec:

--- a/modules/karpenter-provisioner/config/ipv4-values.yaml
+++ b/modules/karpenter-provisioner/config/ipv4-values.yaml
@@ -10,8 +10,7 @@ provisioner_name: "${provisioner_name}"
 instance_capacity_type: "${instance_capacity_type}"
 kms_key_id: "${kms_key_id}"
 ec2_node_name: "${ec2_node_name}"
-tag_product: "${tag_product}"
-tag_environment: "${tag_environment}"
+
 
 
 spec:

--- a/modules/karpenter-provisioner/config/ipv6-values.yaml
+++ b/modules/karpenter-provisioner/config/ipv6-values.yaml
@@ -11,6 +11,8 @@ karpenter_instance_hypervisor: "${instance_hypervisor}"
 instance_capacity_type: "${instance_capacity_type}"
 kms_key_id: "${kms_key_id}"
 ec2_node_name: "${ec2_node_name}"
+tag_product: "${tag_product}"
+tag_environment: "${tag_environment}"
 
 spec:
   labels:

--- a/modules/karpenter-provisioner/config/ipv6-values.yaml
+++ b/modules/karpenter-provisioner/config/ipv6-values.yaml
@@ -11,8 +11,7 @@ karpenter_instance_hypervisor: "${instance_hypervisor}"
 instance_capacity_type: "${instance_capacity_type}"
 kms_key_id: "${kms_key_id}"
 ec2_node_name: "${ec2_node_name}"
-tag_product: "${tag_product}"
-tag_environment: "${tag_environment}"
+
 
 spec:
   labels:

--- a/modules/karpenter-provisioner/config/templates/provisioner.yaml
+++ b/modules/karpenter-provisioner/config/templates/provisioner.yaml
@@ -50,5 +50,4 @@ spec:
         deleteOnTermination: true
   tags:
     Name: {{ .Values.ec2_node_name }} 
-    Product: {{ .Values.tag_product}}
-    Environment: {{ .Values.tag_environment }}
+

--- a/modules/karpenter-provisioner/config/templates/provisioner.yaml
+++ b/modules/karpenter-provisioner/config/templates/provisioner.yaml
@@ -50,3 +50,5 @@ spec:
         deleteOnTermination: true
   tags:
     Name: {{ .Values.ec2_node_name }} 
+    Product: {{ .Values.tag_product}}
+    Environment: {{ .Values.tag_environment }}

--- a/modules/karpenter-provisioner/main.tf
+++ b/modules/karpenter-provisioner/main.tf
@@ -22,6 +22,8 @@ resource "helm_release" "karpenter_provisioner" {
       instance_hypervisor           = "[${join(",", var.karpenter_config.instance_hypervisor)}]"
       kms_key_id                    = local.kms_key_id
       ec2_node_name                 = "${var.karpenter_config.ec2_node_name}-${var.karpenter_config.provisioner_name}-${count.index}"
+      tag_product                   = var.tag_product
+      tag_environment               = var.tag_environment
     }),
     var.karpenter_config.provisioner_values
     ] : [
@@ -38,6 +40,8 @@ resource "helm_release" "karpenter_provisioner" {
       ec2_instance_type             = "[${join(",", [for s in var.karpenter_config.ec2_instance_type : format("%s", s)])}]",
       kms_key_id                    = local.kms_key_id
       ec2_node_name                 = "${var.karpenter_config.ec2_node_name}-${var.karpenter_config.provisioner_name}-${count.index}"
+      tag_product                   = var.tag_product
+      tag_environment               = var.tag_environment
     }),
     var.karpenter_config.provisioner_values
   ]

--- a/modules/karpenter-provisioner/main.tf
+++ b/modules/karpenter-provisioner/main.tf
@@ -22,8 +22,6 @@ resource "helm_release" "karpenter_provisioner" {
       instance_hypervisor           = "[${join(",", var.karpenter_config.instance_hypervisor)}]"
       kms_key_id                    = local.kms_key_id
       ec2_node_name                 = "${var.karpenter_config.ec2_node_name}-${var.karpenter_config.provisioner_name}-${count.index}"
-      tag_product                   = var.tag_product
-      tag_environment               = var.tag_environment
     }),
     var.karpenter_config.provisioner_values
     ] : [
@@ -40,8 +38,6 @@ resource "helm_release" "karpenter_provisioner" {
       ec2_instance_type             = "[${join(",", [for s in var.karpenter_config.ec2_instance_type : format("%s", s)])}]",
       kms_key_id                    = local.kms_key_id
       ec2_node_name                 = "${var.karpenter_config.ec2_node_name}-${var.karpenter_config.provisioner_name}-${count.index}"
-      tag_product                   = var.tag_product
-      tag_environment               = var.tag_environment
     }),
     var.karpenter_config.provisioner_values
   ]

--- a/modules/karpenter-provisioner/variable.tf
+++ b/modules/karpenter-provisioner/variable.tf
@@ -24,12 +24,3 @@ variable "ipv6_enabled" {
   default     = false
 }
 
-variable "tag_product" {
-  description = "Tag for Product"
-  type        = string
-}
-
-variable "tag_environment" {
-  description = "Tag for Environment"
-  type        = string
-}

--- a/modules/karpenter-provisioner/variable.tf
+++ b/modules/karpenter-provisioner/variable.tf
@@ -23,3 +23,13 @@ variable "ipv6_enabled" {
   type        = bool
   default     = false
 }
+
+variable "tag_product" {
+  description = "Tag for Product"
+  type        = string
+}
+
+variable "tag_environment" {
+  description = "Tag for Environment"
+  type        = string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -594,12 +594,4 @@ variable "karpenter_node_iam_instance_profile" {
   default     = ""
 }
 
-variable "tag_product" {
-  description = "Tag for Product"
-  type        = string
-}
 
-variable "tag_environment" {
-  description = "Tag for Environment"
-  type        = string
-}

--- a/variables.tf
+++ b/variables.tf
@@ -593,3 +593,13 @@ variable "karpenter_node_iam_instance_profile" {
   type        = string
   default     = ""
 }
+
+variable "tag_product" {
+  description = "Tag for Product"
+  type        = string
+}
+
+variable "tag_environment" {
+  description = "Tag for Environment"
+  type        = string
+}


### PR DESCRIPTION
Add additional tags in the terraform-aws-eks-addons module to pass these tags in all the aws resources like EFS , load balancer , EBS Volumes. 
1. Almost all the resources getting the additional tags by default but load balancer and ebs volumes didn't get any kind of additional tags bydefault. So i provide the support in these resources specifically. 