### PR TITLE
Bug fix for certmanager and ingress-nginx

### DIFF
--- a/examples/complete/config/cert-manager.yaml
+++ b/examples/complete/config/cert-manager.yaml
@@ -5,6 +5,7 @@ crds:
   # This option decides if the CRDs should be installed
   # as part of the Helm installation.
   enabled: true
+  keep: false
 ## Node affinity for particular node in which labels key is "Infra-Services" and value is "true"
 
 affinity:

--- a/modules/cert-manager/locals.tf
+++ b/modules/cert-manager/locals.tf
@@ -14,13 +14,20 @@ locals {
     values      = local.default_helm_values
   }
 
-  default_helm_values = [templatefile("${path.module}/config/values.yaml", {
+  default_helm_values = templatefile("${path.module}/config/values.yaml", {
     enable_service_monitor = var.helm_config.enable_service_monitor
-  })]
+  })
+
+  template_values_map = yamldecode(local.default_helm_values)
+  external_values_map = yamldecode(var.helm_config.values[0])
+  helm_config_values = yamlencode(merge(local.template_values_map, local.external_values_map))
 
   helm_config = merge(
     local.default_helm_config,
-    var.helm_config
+    var.helm_config,
+    {
+      values = [local.helm_config_values]
+    }
   )
 
   set_values = concat(

--- a/modules/ingress-nginx/main.tf
+++ b/modules/ingress-nginx/main.tf
@@ -27,6 +27,7 @@ resource "kubernetes_namespace" "this" {
 }
 
 module "helm_addon" {
+  depends_on = [ kubernetes_namespace.this ]
   source = "../helm-addon"
   helm_config = merge(
     {


### PR DESCRIPTION
Added bug fixes for terraform destroy stucks doesn't delete all resources in a single run.
- Resolved cert-manager CRDs not deleting issue
- nginx namespace gets deleted before Ingress-nginx doesn't delete