### PR TITLE
addons version variablize

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -36,6 +36,7 @@ module "eks-addons" {
 
   #EBS-CSI-DRIVER
   enable_amazon_eks_aws_ebs_csi_driver = false # enable EBS CSI Driver
+  ebs_csi_driver_version = "v1.36.0-eksbuild.1"
   amazon_eks_aws_ebs_csi_driver_config = {
     values = [file("${path.module}/config/ebs-csi.yaml")]
   }
@@ -43,23 +44,25 @@ module "eks-addons" {
   ## EBS-STORAGE-CLASS
   single_az_ebs_gp3_storage_class_enabled = false # to enable ebs gp3 storage class
   single_az_sc_config                     = [{ name = "infra-service-sc", zone = "${local.region}a" }]
-
+  
   ## EfS-STORAGE-CLASS
   efs_storage_class_enabled = false # to enable EBS storage class
 
   ## SERVICE-MONITORING-CRDs
   service_monitor_crd_enabled = false # enable service monitor along with K8S-dashboard (required CRD) or when require service monitor in reloader and cert-manager
-
+  
   ## METRIC-SERVER
   metrics_server_enabled     = false # to enable metrics server
+  metrics_server_version     = "3.12.1"
   metrics_server_helm_config = [file("${path.module}/config/metrics-server.yaml")]
   vpa_config = {
     values = [file("${path.module}/config/vpa-crd.yaml")]
   }
-
+  
   ## CLUSTER-AUTOSCALER
   cluster_autoscaler_enabled     = false # to enable cluster autoscaller
   cluster_autoscaler_helm_config = [file("${path.module}/config/cluster-autoscaler.yaml")]
+  cluster_autoscaler_version     = "9.37.0"
 
   ## NODE-TERMINATION-HANDLER
   aws_node_termination_handler_enabled = false # to enable node termination handler
@@ -68,12 +71,14 @@ module "eks-addons" {
     enable_service_monitor = false # to enable monitoring for node termination handler
     enable_notifications   = true
   }
+  aws_node_termination_handler_version = "0.21.0"
 
   ## KEDA
   keda_enabled = false # to enable Keda in the EKS cluster
   keda_helm_config = {
     values = [file("${path.module}/config/keda.yaml")]
   }
+  keda_version = "2.14.2"
 
   ## KARPENTER
   karpenter_enabled = false # to enable Karpenter (installs required CRDs )
@@ -81,6 +86,7 @@ module "eks-addons" {
     enable_service_monitor = false # to enable monitoring for kafalserpenter
     values                 = [file("${path.module}/config/karpenter.yaml")]
   }
+  karpenter_version        = "1.0.6"
 
   ## coreDNS-HPA (cluster-proportional-autoscaler)
   coredns_hpa_enabled = false # to enable core-dns HPA
@@ -93,6 +99,7 @@ module "eks-addons" {
   external_secrets_helm_config = {
     values = [file("${path.module}/config/external-secret.yaml")]
   }
+  external_secrets_version = "0.9.19"
 
   ## CERT-MANAGER
   cert_manager_enabled = false # to enable Cert-manager
@@ -101,6 +108,7 @@ module "eks-addons" {
     enable_service_monitor         = false # to enable monitoring for Cert Manager
     cert_manager_letsencrypt_email = "email@email.com"
   }
+  cert_manager_version = "v1.15.1"
 
   ## CONFIG-RELOADER
   reloader_enabled = false # to enable config reloader in the EKS cluster
@@ -108,6 +116,7 @@ module "eks-addons" {
     values                 = [file("${path.module}/config/reloader.yaml")]
     enable_service_monitor = false # to enable monitoring for reloader
   }
+  reloader_version = "v1.0.115"
 
   ## INGRESS-NGINX
   ingress_nginx_enabled = false # to enable ingress nginx
@@ -118,6 +127,7 @@ module "eks-addons" {
     ingress_class_name     = "nginx" # enter ingress class name according to your requirement (example: "nginx", "internal-ingress")
     namespace              = "nginx" # enter namespace according to the requirement (example: "nginx", "internal-ingress")
   }
+  ingress_nginx_version = "4.11.0"
 
   ## AWS-APPLICATION-LOAD-BALANCER-CONTROLLER
   aws_load_balancer_controller_enabled = false # to enable load balancer controller
@@ -126,6 +136,7 @@ module "eks-addons" {
     namespace                     = "alb" # enter namespace according to the requirement (example: "alb")
     load_balancer_controller_name = "alb" # enter ingress class name according to your requirement (example: "aws-load-balancer-controller")
   }
+  aws_load_balancer_controller_version = "1.8.1"
 
   ## KUBERNETES-DASHBOARD
   kubernetes_dashboard_enabled = false
@@ -135,6 +146,7 @@ module "eks-addons" {
     alb_acm_certificate_arn             = ""                               # If using ALB in above parameter, ensure you provide the ACM certificate ARN for SSL.
     k8s_dashboard_hostname              = "k8s-dashboard.rnd.squareops.in" # Enter Hostname
   }
+  kubernetes_dashboard_version = "6.0.8"
 
   ## ArgoCD
   argocd_enabled = false
@@ -148,6 +160,7 @@ module "eks-addons" {
     argocd_notifications_enabled = false
     ingress_class_name           = "nginx" # enter ingress class name according to your requirement (example: "ingress-nginx", "internal-ingress")
   }
+  argocd_version = "7.3.11"
   argoproject_config = {
     name = "argo-project" # enter name for aro-project appProjects
   }
@@ -161,6 +174,7 @@ module "eks-addons" {
     hostname            = "argocd-workflow.rnd.squareops.in"
     ingress_class_name  = "nginx" # enter ingress class name according to your requirement (example: "ingress-nginx", "internal-ingress")
   }
+  argoworkflow_version = "0.29.2"
 
   # VELERO
   velero_enabled              = false # to enable velero
@@ -180,10 +194,12 @@ module "eks-addons" {
   ## KUBECLARITY
   kubeclarity_enabled  = false # to enable kube clarity
   kubeclarity_hostname = "kubeclarity.prod.in"
+  kubeclarity_version  = "2.23.0"
 
   ## KUBECOST
   kubecost_enabled  = false # to enable kube cost
   kubecost_hostname = "kubecost.prod.in"
+  kubecost_version  = "v2.1.0-eksbuild.1"
 
   ## DEFECT-DOJO
   defectdojo_enabled  = false # to enable defectdojo
@@ -192,4 +208,5 @@ module "eks-addons" {
   ## FALCO
   falco_enabled = false # to enable falco
   slack_webhook = "xoxb-379541400966-iibMHnnoaPzVl"
+  falco_version = "4.0.0"
 }

--- a/main.tf
+++ b/main.tf
@@ -226,12 +226,11 @@ module "metrics-server" {
   source = "./modules/metrics-server"
   count  = var.metrics_server_enabled ? 1 : 0
   helm_config = {
-    version = var.metrics_server_helm_version
+    version = var.metrics_server_version
     values  = var.metrics_server_helm_config
   }
   manage_via_gitops = var.argocd_manage_add_ons
   addon_context     = local.addon_context
-  addon_version     = var.metrics_server_version
 }
 
 ## RELOADER

--- a/main.tf
+++ b/main.tf
@@ -24,6 +24,7 @@ module "aws-ebs-csi-driver" {
     },
     var.self_managed_aws_ebs_csi_driver_helm_config,
   )
+  addon_version                              = var.ebs_csi_driver_version
 }
 
 ## EFS CSI DRIVER
@@ -56,6 +57,7 @@ module "aws-load-balancer-controller" {
   addon_context                 = merge(local.addon_context, { default_repository = local.amazon_container_image_registry_uris[data.aws_region.current.name] })
   namespace                     = var.aws_load_balancer_controller_helm_config.namespace
   load_balancer_controller_name = var.aws_load_balancer_controller_helm_config.load_balancer_controller_name
+  addon_version                 = var.aws_load_balancer_controller_version
 }
 
 ## NODE TERMINATION HANDLER
@@ -72,6 +74,7 @@ module "aws-node-termination-handler" {
   addon_context           = local.addon_context
   enable_service_monitor  = var.aws_node_termination_handler_helm_config.enable_service_monitor
   enable_notifications    = var.aws_node_termination_handler_helm_config.enable_notifications
+  chart_version           = var.aws_node_termination_handler_version
 }
 
 ## VPC-CNI
@@ -102,6 +105,7 @@ module "cert-manager" {
   install_letsencrypt_issuers       = var.cert_manager_install_letsencrypt_r53_issuers
   letsencrypt_email                 = var.cert_manager_helm_config.cert_manager_letsencrypt_email
   kubernetes_svc_image_pull_secrets = var.cert_manager_kubernetes_svc_image_pull_secrets
+  addon_version                           = var.cert_manager_version
 }
 
 ## CERT MANAGER LETSENCRYPT
@@ -124,6 +128,7 @@ module "cluster-autoscaler" {
   }
   manage_via_gitops = var.argocd_manage_add_ons
   addon_context     = local.addon_context
+  addon_version           = var.cluster_autoscaler_version
 }
 
 ## COREDNS HPA
@@ -143,6 +148,7 @@ module "external-secrets" {
   irsa_policies                         = var.external_secrets_irsa_policies
   external_secrets_ssm_parameter_arns   = var.external_secrets_ssm_parameter_arns
   external_secrets_secrets_manager_arns = var.external_secrets_secrets_manager_arns
+  addon_version                               = var.external_secrets_version
 }
 
 ## NGINX INGRESS
@@ -160,6 +166,7 @@ module "ingress-nginx" {
   private_nlb_enabled    = var.private_nlb_enabled
   ingress_class_name     = var.private_nlb_enabled ? "internal-${var.ingress_nginx_config.ingress_class_name}" : var.ingress_nginx_config.ingress_class_name
   enable_service_monitor = var.ingress_nginx_config.enable_service_monitor
+  addon_version          = var.ingress_nginx_version
 }
 
 # INGRESS-NGINX DATA SOURCE
@@ -186,6 +193,7 @@ module "karpenter" {
   addon_context             = local.addon_context
   kms_key_arn               = var.karpenter_enabled ? var.kms_key_arn : ""
   enable_service_monitor    = var.karpenter_helm_config.enable_service_monitor
+  chart_version             = var.karpenter_version
 }
 
 ## KUBERNETES DASHBOARD
@@ -198,6 +206,7 @@ module "kubernetes-dashboard" {
   k8s_dashboard_ingress_load_balancer = var.kubernetes_dashboard_config.k8s_dashboard_ingress_load_balancer
   private_alb_enabled                 = var.kubernetes_dashboard_config.private_alb_enabled
   ingress_class_name                  = var.private_nlb_enabled ? "internal-${var.ingress_nginx_config.ingress_class_name}" : var.ingress_nginx_config.ingress_class_name
+  addon_version                       = var.kubernetes_dashboard_version
 }
 
 ## KEDA
@@ -209,6 +218,7 @@ module "keda" {
   irsa_policies     = var.keda_irsa_policies
   manage_via_gitops = var.argocd_manage_add_ons
   addon_context     = local.addon_context
+  addon_version     = var.keda_version
 }
 
 ## METRIC SERVER
@@ -221,6 +231,7 @@ module "metrics-server" {
   }
   manage_via_gitops = var.argocd_manage_add_ons
   addon_context     = local.addon_context
+  addon_version     = var.metrics_server_version
 }
 
 ## RELOADER
@@ -236,6 +247,7 @@ module "reloader" {
   }
   manage_via_gitops = var.argocd_manage_add_ons
   addon_context     = local.addon_context
+  addon_version     = var.reloader_version
 }
 
 ## SINGLE AZ SC
@@ -283,6 +295,7 @@ module "argocd" {
     ingress_class_name           = var.argocd_config.ingress_class_name
   }
   namespace = var.argocd_config.namespace
+  chart_version   = var.argocd_version
 }
 
 # argo-workflow
@@ -297,6 +310,7 @@ module "argocd-workflow" {
     autoscaling_enabled = var.argoworkflow_config.autoscaling_enabled
   }
   namespace = var.argoworkflow_config.namespace
+  chart_version   = var.argoworkflow_version
 }
 
 # argo-project
@@ -352,7 +366,7 @@ resource "helm_release" "kubeclarity" {
   count      = var.kubeclarity_enabled ? 1 : 0
   name       = "kubeclarity"
   chart      = "kubeclarity"
-  version    = "2.23.0"
+  version    = var.kubeclarity_version
   namespace  = var.kubeclarity_namespace
   repository = "https://openclarity.github.io/kubeclarity"
   values = [
@@ -365,18 +379,11 @@ resource "helm_release" "kubeclarity" {
 
 #Kubecost
 
-data "aws_eks_addon_version" "kubecost" {
-  count              = var.kubecost_enabled ? 1 : 0
-  addon_name         = "kubecost_kubecost"
-  kubernetes_version = data.aws_eks_cluster.eks.version
-  most_recent        = true
-}
-
 resource "aws_eks_addon" "kubecost" {
   count                    = var.kubecost_enabled ? 1 : 0
   cluster_name             = var.eks_cluster_name
   addon_name               = "kubecost_kubecost"
-  addon_version            = data.aws_eks_addon_version.kubecost[0].version
+  addon_version            = var.kubecost_version
   service_account_role_arn = var.worker_iam_role_arn
   preserve                 = true
 }
@@ -495,7 +502,7 @@ resource "helm_release" "falco" {
   chart      = "falco"
   repository = "https://falcosecurity.github.io/charts"
   timeout    = 600
-  version    = "4.0.0"
+  version    = var.falco_version
   values = [
     templatefile("${path.module}/modules/falco/config/values.yaml", {
       slack_webhook = var.slack_webhook

--- a/modules/aws-ebs-csi-driver/main.tf
+++ b/modules/aws-ebs-csi-driver/main.tf
@@ -10,14 +10,13 @@ data "aws_eks_addon_version" "this" {
   addon_name = local.name
   # Need to allow both config routes - for managed and self-managed configs
   kubernetes_version = try(var.addon_config.kubernetes_version, var.helm_config.kubernetes_version)
-  most_recent        = true
 }
 
 resource "aws_eks_addon" "aws_ebs_csi_driver" {
   count                    = var.enable_amazon_eks_aws_ebs_csi_driver && !var.enable_self_managed_aws_ebs_csi_driver ? 1 : 0
   cluster_name             = var.addon_context.eks_cluster_id
   addon_name               = local.name
-  addon_version            = try(var.addon_config.addon_version, data.aws_eks_addon_version.this.version)
+  addon_version            = var.addon_version
   service_account_role_arn = local.create_irsa ? module.irsa_addon[0].irsa_iam_role_arn : try(var.addon_config.service_account_role_arn, null)
   preserve                 = try(var.addon_config.preserve, true)
   configuration_values     = jsonencode({ node = { enableWindows = false } })

--- a/modules/aws-ebs-csi-driver/variables.tf
+++ b/modules/aws-ebs-csi-driver/variables.tf
@@ -38,3 +38,9 @@ variable "helm_config" {
   type        = any
   default     = {}
 }
+
+variable "addon_version" {
+  description = "EKS addon version for ebs csi driver"
+  type        = string
+  default     = ""
+}

--- a/modules/aws-load-balancer-controller/locals.tf
+++ b/modules/aws-load-balancer-controller/locals.tf
@@ -9,7 +9,7 @@ locals {
     create_namespace = true
     chart            = "aws-load-balancer-controller"
     repository       = "https://aws.github.io/eks-charts"
-    version          = "1.8.1"
+    version          = var.addon_version
     values           = [yamlencode(merge(local.default_helm_values_map, local.helm_config_map))]
     description      = "aws-load-balancer-controller Helm Chart for ingress resources"
   }

--- a/modules/aws-load-balancer-controller/variables.tf
+++ b/modules/aws-load-balancer-controller/variables.tf
@@ -39,3 +39,9 @@ variable "namespace" {
   type        = string
   default     = "kube-system"
 }
+
+variable "addon_version" {
+  description = "Kubernetes Dashboard Version"
+  type        = string
+  default     = ""
+}

--- a/modules/aws-node-termination-handler/locals.tf
+++ b/modules/aws-node-termination-handler/locals.tf
@@ -8,7 +8,7 @@ locals {
     name        = local.name
     chart       = local.name
     repository  = "https://aws.github.io/eks-charts"
-    version     = "0.21.0"
+    version     = var.chart_version
     namespace   = local.namespace
     description = "AWS Node Termination Handler Helm Chart"
     values      = local.default_helm_values

--- a/modules/aws-vpc-cni/main.tf
+++ b/modules/aws-vpc-cni/main.tf
@@ -13,7 +13,7 @@ data "aws_eks_addon_version" "this" {
 resource "aws_eks_addon" "vpc_cni" {
   cluster_name             = var.addon_context.eks_cluster_id
   addon_name               = local.name
-  addon_version            = try(var.addon_config.version, data.aws_eks_addon_version.this.version)
+  addon_version            = var.addon_config.version
   service_account_role_arn = local.create_irsa ? module.irsa_addon[0].irsa_iam_role_arn : try(var.addon_config.service_account_role_arn, null)
   preserve                 = try(var.addon_config.preserve, true)
 

--- a/modules/cert-manager/locals.tf
+++ b/modules/cert-manager/locals.tf
@@ -7,7 +7,7 @@ locals {
     name       = local.name
     chart      = local.name
     repository = "https://charts.jetstack.io"
-    version    = "v1.15.1"
+    version    = var.addon_version
 
     namespace   = local.name
     description = "Cert Manager Add-on"

--- a/modules/cert-manager/variables.tf
+++ b/modules/cert-manager/variables.tf
@@ -56,3 +56,9 @@ variable "kubernetes_svc_image_pull_secrets" {
   type        = list(string)
   default     = []
 }
+
+variable "addon_version" {
+  description = "cert manager helm version"
+  type        = string
+  default     = ""
+}

--- a/modules/cluster-autoscaler/main.tf
+++ b/modules/cluster-autoscaler/main.tf
@@ -28,7 +28,7 @@ module "helm_addon" {
   helm_config = merge({
     name        = local.name
     chart       = local.name
-    version     = "9.37.0"
+    version     = var.addon_version
     repository  = "https://kubernetes.github.io/autoscaler"
     namespace   = local.namespace
     description = "Cluster AutoScaler helm Chart deployment configuration."

--- a/modules/cluster-autoscaler/variables.tf
+++ b/modules/cluster-autoscaler/variables.tf
@@ -31,3 +31,9 @@ variable "addon_context" {
     irsa_iam_permissions_boundary  = string
   })
 }
+
+variable "addon_version" {
+  description = "Helm chart version of cluster autoscaler"
+  type        = string
+  default     = ""
+}

--- a/modules/external-secret/locals.tf
+++ b/modules/external-secret/locals.tf
@@ -8,7 +8,7 @@ locals {
       name        = local.name
       chart       = local.name
       repository  = "https://charts.external-secrets.io/"
-      version     = "0.9.19"
+      version     = var.addon_version
       namespace   = local.name
       description = "The External Secrets Operator Helm chart default configuration"
     },

--- a/modules/external-secret/variables.tf
+++ b/modules/external-secret/variables.tf
@@ -44,3 +44,9 @@ variable "external_secrets_secrets_manager_arns" {
   type        = list(string)
   default     = ["arn:aws:secretsmanager:*:*:secret:*"]
 }
+
+variable "addon_version" {
+  description = "external secrets helm chart version"
+  type        = string
+  default     = ""
+}

--- a/modules/falco/main.tf
+++ b/modules/falco/main.tf
@@ -13,7 +13,7 @@ resource "helm_release" "falco" {
   chart      = "falco"
   repository = "https://falcosecurity.github.io/charts"
   timeout    = 600
-  version    = "4.0.0"
+  version    = var.version
   values = [
     templatefile("${path.module}/values.yaml", {
       slack_webhook = var.slack_webhook

--- a/modules/falco/variable.tf
+++ b/modules/falco/variable.tf
@@ -9,3 +9,9 @@ variable "slack_webhook" {
   type        = string
   default     = ""
 }
+
+variable "version" {
+  description = "Helm Chart version of Falco"
+  type        = string
+  default     = ""
+}

--- a/modules/ingress-nginx/main.tf
+++ b/modules/ingress-nginx/main.tf
@@ -34,7 +34,7 @@ module "helm_addon" {
       name        = var.ingress_class_name
       chart       = "ingress-nginx"
       repository  = "https://kubernetes.github.io/ingress-nginx"
-      version     = "4.11.0"
+      version     = var.addon_version
       namespace   = var.namespace
       description = "The NGINX HelmChart Ingress Controller deployment configuration"
       values      = [yamlencode(merge(local.template_values_map, var.helm_config))]

--- a/modules/ingress-nginx/variables.tf
+++ b/modules/ingress-nginx/variables.tf
@@ -54,3 +54,9 @@ variable "namespace" {
   description = "Creates namespace for the controller need to install"
   type        = string
 }
+
+variable "addon_version" {
+  description = "Ingress Nginx helm chart version"
+  type        = string
+  default     = ""
+}

--- a/modules/keda/locals.tf
+++ b/modules/keda/locals.tf
@@ -8,7 +8,7 @@ locals {
       name        = local.name
       chart       = local.name
       repository  = "https://kedacore.github.io/charts"
-      version     = "2.14.2"
+      version     = var.addon_version
       namespace   = local.name
       description = "Keda Event-based autoscaler for workloads on Kubernetes"
       values      = [file("${path.module}/config/values.yaml")]

--- a/modules/keda/variables.tf
+++ b/modules/keda/variables.tf
@@ -32,3 +32,9 @@ variable "addon_context" {
     irsa_iam_permissions_boundary  = string
   })
 }
+
+variable "addon_version" {
+  description = "Helm version of keda"
+  type        = string
+  default     = ""
+}

--- a/modules/kubernetes-dashboard/main.tf
+++ b/modules/kubernetes-dashboard/main.tf
@@ -15,7 +15,7 @@ resource "helm_release" "kubernetes-dashboard" {
   chart      = "kubernetes-dashboard"
   repository = "https://kubernetes.github.io/dashboard/"
   timeout    = 600
-  version    = "6.0.8"
+  version    = var.addon_version
 }
 
 resource "kubernetes_ingress_v1" "k8s-ingress" {

--- a/modules/kubernetes-dashboard/variables.tf
+++ b/modules/kubernetes-dashboard/variables.tf
@@ -27,3 +27,9 @@ variable "private_alb_enabled" {
   type        = bool
   default     = false
 }
+
+variable "addon_version" {
+  description = "Helm Chart version for Kubernetes-dashboard"
+  default     = ""
+  type        = string
+}

--- a/modules/metrics-server/locals.tf
+++ b/modules/metrics-server/locals.tf
@@ -6,7 +6,7 @@ locals {
     name        = local.name
     chart       = local.name
     repository  = "https://kubernetes-sigs.github.io/metrics-server/"
-    version     = var.addon_version
+    version     = var.helm_config.version
     namespace   = "kube-system"
     description = "Metric server helm Chart deployment configuration"
   }

--- a/modules/metrics-server/locals.tf
+++ b/modules/metrics-server/locals.tf
@@ -6,7 +6,7 @@ locals {
     name        = local.name
     chart       = local.name
     repository  = "https://kubernetes-sigs.github.io/metrics-server/"
-    version     = "3.12.1"
+    version     = var.addon_version
     namespace   = "kube-system"
     description = "Metric server helm Chart deployment configuration"
   }

--- a/modules/metrics-server/variables.tf
+++ b/modules/metrics-server/variables.tf
@@ -24,3 +24,9 @@ variable "addon_context" {
     tags                           = map(string)
   })
 }
+
+variable "addon_version" {
+  description = "Helm Chart version for Metrics Server"
+  type        = string
+  default     = ""
+}

--- a/modules/reloader/main.tf
+++ b/modules/reloader/main.tf
@@ -16,7 +16,7 @@ module "helm_addon" {
       name             = local.name
       chart            = local.name
       repository       = "https://stakater.github.io/stakater-charts"
-      version          = "v1.0.115"
+      version          = var.addon_version
       namespace        = local.name
       create_namespace = true
       description      = "Reloader Helm Chart deployment configuration"

--- a/modules/reloader/variables.tf
+++ b/modules/reloader/variables.tf
@@ -26,3 +26,9 @@ variable "addon_context" {
     irsa_iam_permissions_boundary  = string
   })
 }
+
+variable "addon_version" {
+  description = "reloader helm chart version"
+  type        = string
+  default     = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -740,7 +740,7 @@ variable "kubeclarity_version" {
 
 variable "kubecost_version" {
   description = "Version of the kubecost addon"
-  default     = "1.108.1"
+  default     = "v2.1.0-eksbuild.1"
   type        = string
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -646,3 +646,106 @@ variable "karpenter_node_iam_instance_profile" {
   type        = string
   default     = ""
 }
+
+
+variable "ebs_csi_driver_version" {
+  description = "Version of the ebs csi driver addon"
+  default     = "v1.36.0-eksbuild.1"
+  type        = string
+}
+
+variable "metrics_server_version" {
+  description = "Version of the metrics server addon"
+  default     = "3.12.1"
+  type        = string
+}
+
+variable "cluster_autoscaler_version" {
+  description = "Version of the cluster autoscaler addon"
+  default     = "9.37.0"
+  type        = string
+}
+
+variable "aws_node_termination_handler_version" {
+  description = "Version of the aws node termination handler addon"
+  default     = "0.21.0"
+  type        = string
+}
+
+variable "keda_version" {
+  description = "Version of the keda addon"
+  default     = "2.14.2"
+  type        = string
+}
+
+variable "karpenter_version" {
+  description = "Version of the karpenter addon"
+  default     = "1.0.6"
+  type        = string
+}
+
+variable "external_secrets_version" {
+  description = "Version of the external secrets addon"
+  default     = "0.9.19"
+  type        = string
+}
+
+variable "cert_manager_version" {
+  description = "Version of the cert manager addon"
+  default     = "v1.15.1"
+  type        = string
+}
+
+variable "reloader_version" {
+  description = "Version of the reloader addon"
+  default     = "v1.0.115"
+  type        = string
+}
+
+variable "ingress_nginx_version" {
+  description = "Version of the ingress nginx addon"
+  default     = "4.11.0"
+  type        = string
+}
+
+variable "aws_load_balancer_controller_version" {
+  description = "Version of the aws load balancer controller addon"
+  default     = "1.8.1"
+  type        = string
+}
+
+variable "kubernetes_dashboard_version" {
+  description = "Version of the kubernetes dashboard addon"
+  default     = "6.0.8"
+  type        = string
+}
+
+variable "argocd_version" {
+  description = "Version of the argocd addon"
+  default     = "7.3.11"
+  type        = string
+}
+
+variable "argoworkflow_version" {
+  description = "Version of the argoworkflow addon"
+  default     = "0.29.2"
+  type        = string
+}
+
+variable "kubeclarity_version" {
+  description = "Version of the kubeclarity addon"
+  default     = "2.23.0"
+  type        = string
+}
+
+variable "kubecost_version" {
+  description = "Version of the kubecost addon"
+  default     = "1.108.1"
+  type        = string
+}
+
+variable "falco_version" {
+  description = "Version of the falco addon"
+  default     = "4.0.0"
+  type        = string
+}


### PR DESCRIPTION
Variablized the below addons and freezed their version:
vpc-cni "v1.19.0-eksbuild.1"
ebs-csi-driver "v1.36.0-eksbuild.1"
metrics-server "3.12.1"
cluster-autoscaler "9.37.0"
node-termination-handler "0.21.0"
keda "2.14.2"
Karpenter "1.0.6"
external-secret "0.9.19"
cert-manager v1.15.1"
reloader "v1.0.115"
Ingress-nginx "4.11.0"
load-balancer-controller "1.8.1"
kubenetes-dashboard "6.0.8"
argocd "7.3.11"
argoworkflow "0.29.2"
kubeclarity "2.23.0"
kubecost "v2.1.0-eksbuild.1"
falco "4.0.0"