### PR TITLE
removed deprecated annotation from ingress-nginx.yaml

### DIFF
--- a/modules/ingress-nginx/config/ingress_nginx.yaml
+++ b/modules/ingress-nginx/config/ingress_nginx.yaml
@@ -7,6 +7,7 @@ controller:
       service.beta.kubernetes.io/aws-load-balancer-type: nlb
       service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
       service.beta.kubernetes.io/aws-load-balancer-subnets: ${nlb_subnets}
+      service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: "${additional_tags}"
     externalTrafficPolicy: Cluster
   ingressClassResource:
     enabled: true

--- a/modules/ingress-nginx/config/ingress_nginx.yaml
+++ b/modules/ingress-nginx/config/ingress_nginx.yaml
@@ -6,7 +6,6 @@ controller:
     annotations:
       service.beta.kubernetes.io/aws-load-balancer-type: nlb
       service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
-      service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: "${additional_tags}"
       service.beta.kubernetes.io/aws-load-balancer-subnets: ${nlb_subnets}
     externalTrafficPolicy: Cluster
   ingressClassResource:

--- a/modules/ingress-nginx/config/ingress_nginx.yaml
+++ b/modules/ingress-nginx/config/ingress_nginx.yaml
@@ -5,7 +5,6 @@ controller:
     enabled: true
     annotations:
       service.beta.kubernetes.io/aws-load-balancer-type: nlb
-      service.beta.kubernetes.io/aws-load-balancer-internal: "${private_nlb_enabled}"
       service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
       service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: "${additional_tags}"
       service.beta.kubernetes.io/aws-load-balancer-subnets: ${nlb_subnets}


### PR DESCRIPTION
**Removed this deprecated annotations from ingress-nginx.yaml file.** 

service.beta.kubernetes.io/aws-load-balancer-internal: "${private_nlb_enabled}"